### PR TITLE
Adds webOS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,6 +364,21 @@ ifeq ($(STATIC_LINKING), 1)
    endif
 endif
 
+# webOS
+ifneq (,$(or $(findstring webos,$(CROSS_COMPILE)),$(findstring starfish,$(CROSS_COMPILE))))
+   GLES = 1
+   GL_LIB := -lGLESv2
+   ifneq (,$(findstring arm,$(CROSS_COMPILE)))
+      HAVE_NEON = 1
+      WITH_DYNAREC = arm
+   else
+      WITH_DYNAREC = aarch64
+   endif
+   # GCC 14 fixes for multiple definitions
+   CFLAGS   += -fcommon
+   CXXFLAGS += -fcommon
+endif
+
 include Makefile.common
 
 ifeq ($(HAVE_NEON), 1)

--- a/Makefile.common
+++ b/Makefile.common
@@ -387,13 +387,6 @@ SOURCES_C += $(LIBRETRO_COMM_DIR)/libco/libco.c
 
 SOURCES_C += $(CXD4DIR)/rsp.c 
 
-ifeq ($(HAVE_NEON),1)
-
-	SOURCES_ASM += $(LIBRETRO_COMM_DIR)/audio/conversion/float_to_s16_neon.S \
-						$(LIBRETRO_COMM_DIR)/audio/conversion/s16_to_float_neon.S \
-						$(LIBRETRO_COMM_DIR)/audio/resampler/drivers/sinc_resampler_neon.S
-endif
-
 ifeq ($(HAVE_PARALLEL),1)
 CFLAGS   += -DHAVE_PARALLEL
 CXXFLAGS += -DHAVE_PARALLEL

--- a/mupen64plus-core/src/device/r4300/idec.h
+++ b/mupen64plus-core/src/device/r4300/idec.h
@@ -82,6 +82,6 @@ size_t idec_u53(uint32_t iw, uint8_t u53, uint8_t* u5);
 
 #define IDEC_U53(r4300, iw, u53, u5) (void*)(((char*)(r4300)) + idec_u53((iw), (u53), (u5)))
 
-const char* g_r4300_opcodes[R4300_OPCODES_COUNT];
+extern const char* g_r4300_opcodes[R4300_OPCODES_COUNT];
 
 #endif

--- a/mupen64plus-core/subprojects/minizip/zip.c
+++ b/mupen64plus-core/subprojects/minizip/zip.c
@@ -1246,7 +1246,7 @@ extern int ZEXPORT zipOpenNewFileInZip4_64 (zipFile file, const char* filename, 
         unsigned char bufHead[RAND_HEAD_LEN];
         unsigned int sizeHead;
         zi->ci.encrypt = 1;
-        zi->ci.pcrc_32_tab = get_crc_table();
+        zi->ci.pcrc_32_tab = (const unsigned long *)get_crc_table();
         /*init_keys(password,zi->ci.keys,zi->ci.pcrc_32_tab);*/
 
         sizeHead=crypthead(password,bufHead,RAND_HEAD_LEN,zi->ci.keys,zi->ci.pcrc_32_tab,crcForCrypting);

--- a/mupen64plus-video-angrylion/parallel_al.cpp
+++ b/mupen64plus-video-angrylion/parallel_al.cpp
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <thread>
 #include <vector>
+#include <stdexcept>
 
 class Parallel
 {


### PR DESCRIPTION
Fixes a few GCC 14 issues e.g. these are added twice:

```
SOURCES_ASM += $(LIBRETRO_COMM_DIR)/audio/conversion/float_to_s16_neon.S 
```

Adds webOS to Makefile